### PR TITLE
Removed "experimental-webgl2" calls, since they are deprecated.

### DIFF
--- a/AdditionalMaterials/Documentation/core_gl.js.html
+++ b/AdditionalMaterials/Documentation/core_gl.js.html
@@ -82,10 +82,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("&lt;br>&lt;b>WebGL 2 is not supported!&lt;/b>");

--- a/AdditionalMaterials/ExtraExamples/5.5.multi-_texture_investigation/texture_renderable_with_two_textures_(5.4)/src/engine/core/gl.js
+++ b/AdditionalMaterials/ExtraExamples/5.5.multi-_texture_investigation/texture_renderable_with_two_textures_(5.4)/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+        // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/AdditionalMaterials/ExtraExamples/8.3.a.patterned-light/src/engine/core/gl.js
+++ b/AdditionalMaterials/ExtraExamples/8.3.a.patterned-light/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/AdditionalMaterials/ExtraExamples/Winter-2023-ControllerAPI-Bhardwaj_DeGuia_Le/src/engine/core/gl.js
+++ b/AdditionalMaterials/ExtraExamples/Winter-2023-ControllerAPI-Bhardwaj_DeGuia_Le/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/AdditionalMaterials/Tutorials/Tutorial-Source/src/engine/core/gl.js
+++ b/AdditionalMaterials/Tutorials/Tutorial-Source/src/engine/core/gl.js
@@ -54,10 +54,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter10/10.1.particles/src/engine/core/gl.js
+++ b/BookSourceCode/chapter10/10.1.particles/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter10/10.2.particle_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter10/10.2.particle_collisions/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter10/10.3.particle_emitters/src/engine/core/gl.js
+++ b/BookSourceCode/chapter10/10.3.particle_emitters/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter11/11.1.tiled_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter11/11.1.tiled_objects/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter11/11.2.parallax_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter11/11.2.parallax_objects/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter11/11.3.layer_manager/src/engine/core/gl.js
+++ b/BookSourceCode/chapter11/11.3.layer_manager/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter12/src/engine/core/gl.js
+++ b/BookSourceCode/chapter12/src/engine/core/gl.js
@@ -54,10 +54,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter2/2.1.html5_canvas/index.html
+++ b/BookSourceCode/chapter2/2.1.html5_canvas/index.html
@@ -19,11 +19,10 @@
                 // Begin of code execution
                 let canvas = document.getElementById("GLCanvas");
     
-                // Get standard webgl2, or experimental
+                // Get standard webgl2
                 // binds webgl2 to the Canvas area on the web-page to the variable "gl"
                 // "gl" will be the context upon which we access all webGL2 functionality
-                let gl = canvas.getContext("webgl2") ||
-                         canvas.getContext("experimental-webgl2");
+                let gl = canvas.getContext("webgl2");
     
                 if (gl !== null) {
                     gl.clearColor(0.0, 0.8, 0.0, 1.0);  // set the color to be cleared

--- a/BookSourceCode/chapter2/2.2.javascript_source_file/src/core.js
+++ b/BookSourceCode/chapter2/2.2.javascript_source_file/src/core.js
@@ -16,9 +16,9 @@ function getGL() { return mGL; }
 function initWebGL(htmlCanvasID) {
     let canvas = document.getElementById(htmlCanvasID);
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = canvas.getContext("webgl2") || canvas.getContext("experimental-webgl2");
+    mGL = canvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter2/2.3.draw_one_square/src/core.js
+++ b/BookSourceCode/chapter2/2.3.draw_one_square/src/core.js
@@ -21,9 +21,9 @@ function getGL() { return mGL; }
 function initWebGL(htmlCanvasID) {
     let canvas = document.getElementById(htmlCanvasID);
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = canvas.getContext("webgl2") || canvas.getContext("experimental-webgl2");
+    mGL = canvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter2/2.4.javascript_objects/src/engine/core.js
+++ b/BookSourceCode/chapter2/2.4.javascript_objects/src/engine/core.js
@@ -26,9 +26,9 @@ function createShader() {
 function initWebGL(htmlCanvasID) {
     let canvas = document.getElementById(htmlCanvasID);
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = canvas.getContext("webgl2") || canvas.getContext("experimental-webgl2");
+    mGL = canvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter2/2.5.shader_source_files/src/engine/core.js
+++ b/BookSourceCode/chapter2/2.5.shader_source_files/src/engine/core.js
@@ -26,9 +26,9 @@ function createShader() {
 function initWebGL(htmlCanvasID) {
     let canvas = document.getElementById(htmlCanvasID);
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = canvas.getContext("webgl2") || canvas.getContext("experimental-webgl2");
+    mGL = canvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter2/2.6.parameterized_fragment_shader/src/engine/core.js
+++ b/BookSourceCode/chapter2/2.6.parameterized_fragment_shader/src/engine/core.js
@@ -26,9 +26,9 @@ function createShader() {
 function initWebGL(htmlCanvasID) {
     let canvas = document.getElementById(htmlCanvasID);
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = canvas.getContext("webgl2") || canvas.getContext("experimental-webgl2");
+    mGL = canvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter3/3.1.renderable_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter3/3.1.renderable_objects/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter3/3.2.matrix_transform/src/engine/core/gl.js
+++ b/BookSourceCode/chapter3/3.2.matrix_transform/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter3/3.3.transform_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter3/3.3.transform_objects/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter3/3.4.camera_transform_and_viewport/src/engine/core/gl.js
+++ b/BookSourceCode/chapter3/3.4.camera_transform_and_viewport/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter3/3.5.camera_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter3/3.5.camera_objects/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter4/4.1.game_loop/src/engine/core/gl.js
+++ b/BookSourceCode/chapter4/4.1.game_loop/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter4/4.2.keyboard_support/src/engine/core/gl.js
+++ b/BookSourceCode/chapter4/4.2.keyboard_support/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter4/4.3.resource_map_and_shader_loader/src/engine/core/gl.js
+++ b/BookSourceCode/chapter4/4.3.resource_map_and_shader_loader/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter4/4.4.scene_files/src/engine/core/gl.js
+++ b/BookSourceCode/chapter4/4.4.scene_files/src/engine/core/gl.js
@@ -16,9 +16,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter4/4.5.scene_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter4/4.5.scene_objects/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter4/4.6.audio_support/src/engine/core/gl.js
+++ b/BookSourceCode/chapter4/4.6.audio_support/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2") || mCanvas.getContext("experimental-webgl2");
+    mGL = mCanvas.getContext("webgl2");
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter5/5.1.texture_shaders/src/engine/core/gl.js
+++ b/BookSourceCode/chapter5/5.1.texture_shaders/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter5/5.2.sprite_shaders/src/engine/core/gl.js
+++ b/BookSourceCode/chapter5/5.2.sprite_shaders/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter5/5.3.sprite_animate_shaders/src/engine/core/gl.js
+++ b/BookSourceCode/chapter5/5.3.sprite_animate_shaders/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter5/5.4.font_support/src/engine/core/gl.js
+++ b/BookSourceCode/chapter5/5.4.font_support/src/engine/core/gl.js
@@ -31,10 +31,10 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
-
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
+    
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");
         return;

--- a/BookSourceCode/chapter6/6.1.game_objects/src/engine/core/gl.js
+++ b/BookSourceCode/chapter6/6.1.game_objects/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter6/6.2.front_and_chase/src/engine/core/gl.js
+++ b/BookSourceCode/chapter6/6.2.front_and_chase/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter6/6.3.bbox_and_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter6/6.3.bbox_and_collisions/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter6/6.4.per_pixel_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter6/6.4.per_pixel_collisions/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter6/6.5.general_pixel_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter6/6.5.general_pixel_collisions/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter6/6.6.sprite_pixel_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter6/6.6.sprite_pixel_collisions/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter7/7.1.camera_manipulations/src/engine/core/gl.js
+++ b/BookSourceCode/chapter7/7.1.camera_manipulations/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter7/7.2.camera_interpolations/src/engine/core/gl.js
+++ b/BookSourceCode/chapter7/7.2.camera_interpolations/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter7/7.3.camera_shake_and_object_oscillate/src/engine/core/gl.js
+++ b/BookSourceCode/chapter7/7.3.camera_shake_and_object_oscillate/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter7/7.4.multiple_cameras/src/engine/core/gl.js
+++ b/BookSourceCode/chapter7/7.4.multiple_cameras/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter7/7.5.mouse_input/src/engine/core/gl.js
+++ b/BookSourceCode/chapter7/7.5.mouse_input/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter7/7.6.not_used_line_support/src/engine/core/gl.js
+++ b/BookSourceCode/chapter7/7.6.not_used_line_support/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.1.global_ambient/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.1.global_ambient/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.2.simple_light_shader/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.2.simple_light_shader/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.3.multiple_lights/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.3.multiple_lights/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.4.normal_map_and_illumination_shaders/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.4.normal_map_and_illumination_shaders/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.5.material_and_specularity/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.5.material_and_specularity/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.6.directional_and_spotlights/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.6.directional_and_spotlights/src/engine/core/gl.js
@@ -31,9 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false}) || mCanvas.getContext("experimental-webgl2", {alpha: false});
+    mGL = mCanvas.getContext("webgl2", {alpha: false});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter8/8.7.shadow_shaders/src/engine/core/gl.js
+++ b/BookSourceCode/chapter8/8.7.shadow_shaders/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.1.rigid_shapes_and_bounds/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.1.rigid_shapes_and_bounds/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.2.circle_collisions_and_collision_info/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.2.circle_collisions_and_collision_info/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.3.rectangle_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.3.rectangle_collisions/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.4.rectangle_and_circle_collisions/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.4.rectangle_and_circle_collisions/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.5.rigid_shape_movements/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.5.rigid_shape_movements/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.6.collision_position_correction/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.6.collision_position_correction/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.7.collision_resolution/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.7.collision_resolution/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.8.collision_angular_resolution/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.8.collision_angular_resolution/src/engine/core/gl.js
@@ -31,10 +31,9 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
 
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");

--- a/BookSourceCode/chapter9/9.9.physics_presets/src/engine/core/gl.js
+++ b/BookSourceCode/chapter9/9.9.physics_presets/src/engine/core/gl.js
@@ -31,11 +31,10 @@ function init(htmlCanvasID) {
     if (mCanvas == null)
         throw new Error("Engine init [" + htmlCanvasID + "] HTML element id not found");
 
-    // Get the standard or experimental webgl and binds to the Canvas area
+    // Get the standard webgl and binds to the Canvas area
     // store the results to the instance variable mGL
-    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true}) || 
-          mCanvas.getContext("experimental-webgl2", {alpha: false, depth: true, stencil: true});
-
+    mGL = mCanvas.getContext("webgl2", {alpha: false, depth: true, stencil: true});
+    
     if (mGL === null) {
         document.write("<br><b>WebGL 2 is not supported!</b>");
         return;


### PR DESCRIPTION
Removed "experimental-webgl2" calls, since they are deprecated.
In the MDN you can see, that "experimental-webgl2" is not being mentioned any more ([https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#return_value](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#return_value)). For getting "WebGL2RenderingContext" you can only use "webgl2".

Others got rid of it as well ([https://hg.mozilla.org/mozilla-central/rev/d1f3d202a195](https://hg.mozilla.org/mozilla-central/rev/d1f3d202a195))

On ([webgl2fundamentals.org](webgl2fundamentals.org)) it also says that "experimental-webgl2" is deprecated ([https://webgl2fundamentals.org/webgl/lessons/webgl1-to-webgl2.html](https://webgl2fundamentals.org/webgl/lessons/webgl1-to-webgl2.html))